### PR TITLE
Refactor TeacherScheduleRepository for Clean Architecture Compliance

### DIFF
--- a/core/data/src/main/java/com/wei/amazingtalker/core/data/model/TeacherSchedule.kt
+++ b/core/data/src/main/java/com/wei/amazingtalker/core/data/model/TeacherSchedule.kt
@@ -1,0 +1,16 @@
+package com.wei.amazingtalker.core.data.model
+
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
+import com.wei.amazingtalker.core.model.data.TimeSlots
+import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
+import com.wei.amazingtalker.core.network.model.NetworkTimeSlots
+
+fun NetworkTeacherSchedule.asExternalModel() = TeacherSchedule(
+    available = this.available.map { it.asExternalModel() },
+    booked = this.booked.map { it.asExternalModel() },
+)
+
+fun NetworkTimeSlots.asExternalModel() = TimeSlots(
+    startUtc = this.startUtc,
+    endUtc = this.endUtc,
+)

--- a/core/data/src/main/java/com/wei/amazingtalker/core/data/repository/DefaultTeacherScheduleRepository.kt
+++ b/core/data/src/main/java/com/wei/amazingtalker/core/data/repository/DefaultTeacherScheduleRepository.kt
@@ -1,9 +1,10 @@
 package com.wei.amazingtalker.core.data.repository
 
+import com.wei.amazingtalker.core.data.model.asExternalModel
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
 import com.wei.amazingtalker.core.network.AtDispatchers
 import com.wei.amazingtalker.core.network.AtNetworkDataSource
 import com.wei.amazingtalker.core.network.Dispatcher
-import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -30,9 +31,9 @@ class DefaultTeacherScheduleRepository @Inject constructor(
     override suspend fun getTeacherAvailability(
         teacherName: String,
         startedAt: String,
-    ): Flow<NetworkTeacherSchedule> = withContext(ioDispatcher) {
+    ): Flow<TeacherSchedule> = withContext(ioDispatcher) {
         flow {
-            emit(network.getTeacherAvailability(teacherName, startedAt))
+            emit(network.getTeacherAvailability(teacherName, startedAt).asExternalModel())
         }
     }
 }

--- a/core/data/src/main/java/com/wei/amazingtalker/core/data/repository/TeacherScheduleRepository.kt
+++ b/core/data/src/main/java/com/wei/amazingtalker/core/data/repository/TeacherScheduleRepository.kt
@@ -1,9 +1,9 @@
 package com.wei.amazingtalker.core.data.repository
 
-import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
 import kotlinx.coroutines.flow.Flow
 
 interface TeacherScheduleRepository {
 
-    suspend fun getTeacherAvailability(teacherName: String, startedAt: String): Flow<NetworkTeacherSchedule>
+    suspend fun getTeacherAvailability(teacherName: String, startedAt: String): Flow<TeacherSchedule>
 }

--- a/core/domain/src/main/java/com/wei/amazingtalker/core/domain/IntervalizeScheduleUseCase.kt
+++ b/core/domain/src/main/java/com/wei/amazingtalker/core/domain/IntervalizeScheduleUseCase.kt
@@ -3,7 +3,7 @@ package com.wei.amazingtalker.core.domain
 import com.wei.amazingtalker.core.extensions.getDuringDayType
 import com.wei.amazingtalker.core.model.data.IntervalScheduleTimeSlot
 import com.wei.amazingtalker.core.model.data.ScheduleState
-import com.wei.amazingtalker.core.network.model.NetworkTimeSlots
+import com.wei.amazingtalker.core.model.data.TimeSlots
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneId
@@ -27,7 +27,7 @@ class IntervalizeScheduleUseCase @Inject constructor() {
     private val currentTimezone = ZoneId.systemDefault()
 
     operator fun invoke(
-        teacherScheduleList: List<NetworkTimeSlots>,
+        teacherScheduleList: List<TimeSlots>,
         timeInterval: TimeInterval,
         scheduleState: ScheduleState,
     ): List<IntervalScheduleTimeSlot> {

--- a/core/domain/src/test/java/com/wei/amazingtalker/core/domain/IntervalizeScheduleUseCaseTest.kt
+++ b/core/domain/src/test/java/com/wei/amazingtalker/core/domain/IntervalizeScheduleUseCaseTest.kt
@@ -3,8 +3,8 @@ package com.wei.amazingtalker.core.domain
 import com.google.common.truth.Truth.assertThat
 import com.wei.amazingtalker.core.model.data.IntervalScheduleTimeSlot
 import com.wei.amazingtalker.core.model.data.ScheduleState
-import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
-import com.wei.amazingtalker.core.network.model.NetworkTimeSlots
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
+import com.wei.amazingtalker.core.model.data.TimeSlots
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,7 +32,7 @@ class IntervalizeScheduleUseCaseTest(
         }
     }
 
-    private lateinit var internalTestSchedules: NetworkTeacherSchedule
+    private lateinit var internalTestSchedules: TeacherSchedule
     private val useCase = IntervalizeScheduleUseCase()
 
     /**
@@ -85,32 +85,32 @@ class IntervalizeScheduleUseCaseTest(
     }
 }
 
-private val testSchedules = NetworkTeacherSchedule(
+private val testSchedules = TeacherSchedule(
     available = listOf(
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T04:30:00Z",
             endUtc = "2023-07-31T09:30:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T12:30:00Z",
             endUtc = "2023-07-31T18:30:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T19:30:00Z",
             endUtc = "2023-07-31T20:30:00Z",
         ),
         // More Data...
     ),
     booked = listOf(
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T09:30:00Z",
             endUtc = "2023-07-31T10:30:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T11:30:00Z",
             endUtc = "2023-07-31T12:30:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T18:30:00Z",
             endUtc = "2023-07-31T19:30:00Z",
         ),

--- a/core/model/src/main/java/com/wei/amazingtalker/core/model/data/TeacherSchedule.kt
+++ b/core/model/src/main/java/com/wei/amazingtalker/core/model/data/TeacherSchedule.kt
@@ -1,0 +1,11 @@
+package com.wei.amazingtalker.core.model.data
+
+data class TeacherSchedule(
+    val available: List<TimeSlots> = emptyList(),
+    val booked: List<TimeSlots> = emptyList(),
+)
+
+data class TimeSlots(
+    val startUtc: String,
+    val endUtc: String,
+)

--- a/core/testing/src/main/java/com/wei/amazingtalker/core/testing/repository/TestTeacherScheduleRepository.kt
+++ b/core/testing/src/main/java/com/wei/amazingtalker/core/testing/repository/TestTeacherScheduleRepository.kt
@@ -1,7 +1,7 @@
 package com.wei.amazingtalker.core.testing.repository
 
 import com.wei.amazingtalker.core.data.repository.TeacherScheduleRepository
-import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -13,34 +13,34 @@ class TestTeacherScheduleRepository : TeacherScheduleRepository {
     private var errorException: Exception? = null
 
     /**
-     * The backing hot flow for the list of [NetworkTeacherSchedule] for testing.
+     * The backing hot flow for the list of [TeacherSchedule] for testing.
      */
-    private val networkTeacherScheduleFlow: MutableSharedFlow<NetworkTeacherSchedule> =
+    private val teacherScheduleFlow: MutableSharedFlow<TeacherSchedule> =
         MutableSharedFlow(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     override suspend fun getTeacherAvailability(
         teacherName: String,
         startedAt: String,
-    ): Flow<NetworkTeacherSchedule> {
+    ): Flow<TeacherSchedule> {
         // If there's an exception, throw it in a flow
         errorException?.let { exception ->
             // This flow is used to simulate an error scenario.
             return flow {
-                emit(NetworkTeacherSchedule(emptyList(), emptyList()))
+                emit(TeacherSchedule(emptyList(), emptyList()))
             }.map {
                 throw exception
             }
         }
 
         // If there's no exception, return the normal flow
-        return networkTeacherScheduleFlow
+        return teacherScheduleFlow
     }
 
     /**
-     * A test-only API to allow controlling the list of NetworkTeacherSchedule from tests.
+     * A test-only API to allow controlling the list of TeacherSchedule from tests.
      */
-    fun sendNetworkTeacherSchedule(networkTeacherSchedules: NetworkTeacherSchedule) {
-        networkTeacherScheduleFlow.tryEmit(networkTeacherSchedules)
+    fun sendTeacherSchedule(teacherSchedules: TeacherSchedule) {
+        teacherScheduleFlow.tryEmit(teacherSchedules)
     }
 
     /**

--- a/feature/teacherschedule/src/test/java/com/wei/amazingtalker/feature/teacherschedule/domain/GetTeacherScheduleUseCaseTest.kt
+++ b/feature/teacherschedule/src/test/java/com/wei/amazingtalker/feature/teacherschedule/domain/GetTeacherScheduleUseCaseTest.kt
@@ -5,8 +5,8 @@ import com.wei.amazingtalker.core.domain.IntervalizeScheduleUseCase
 import com.wei.amazingtalker.core.domain.TimeInterval
 import com.wei.amazingtalker.core.model.data.IntervalScheduleTimeSlot
 import com.wei.amazingtalker.core.model.data.ScheduleState
-import com.wei.amazingtalker.core.network.model.NetworkTeacherSchedule
-import com.wei.amazingtalker.core.network.model.NetworkTimeSlots
+import com.wei.amazingtalker.core.model.data.TeacherSchedule
+import com.wei.amazingtalker.core.model.data.TimeSlots
 import com.wei.amazingtalker.core.result.DataSourceResult
 import com.wei.amazingtalker.core.testing.repository.TestTeacherScheduleRepository
 import com.wei.amazingtalker.core.testing.util.MainDispatcherRule
@@ -57,11 +57,11 @@ class GetTeacherScheduleUseCaseTest {
          * 使用 testSchedules.copy() 確保了每次設置前置條件時都是對原始數據的深度複製，
          * 這確保了每個測試的獨立性，避免了因數據共享而產生的潛在問題。
          */
-        val expectedTeacherSchedule = testNetworkTeacherSchedule.copy()
+        val expectedTeacherSchedule = testTeacherSchedule.copy()
         val expectedIntervalSchedule = generateExpectedIntervalSchedule(expectedTeacherSchedule, scheduleStateTimeInterval)
 
         // Act
-        testTeacherScheduleRepo.sendNetworkTeacherSchedule(testNetworkTeacherSchedule)
+        testTeacherScheduleRepo.sendTeacherSchedule(testTeacherSchedule)
         val resultFlow = getTeacherScheduleUseCase("testTeacherName", "testStartedAtUtc").take(2)
 
         // Assert
@@ -84,7 +84,7 @@ class GetTeacherScheduleUseCaseTest {
         assertThat(result.exception!!.message).isEqualTo(TestTeacherScheduleRepository.ErrorExceptionMessage)
     }
 
-    private fun generateExpectedIntervalSchedule(expectedTeacherSchedule: NetworkTeacherSchedule, scheduleStateTimeInterval: TimeInterval) =
+    private fun generateExpectedIntervalSchedule(expectedTeacherSchedule: TeacherSchedule, scheduleStateTimeInterval: TimeInterval) =
         mutableListOf<IntervalScheduleTimeSlot>().apply {
             addAll(
                 intervalizeScheduleUseCase(
@@ -103,23 +103,23 @@ class GetTeacherScheduleUseCaseTest {
         }.sortedBy { it.start }.toMutableList()
 }
 
-private val testNetworkTeacherSchedule = NetworkTeacherSchedule(
+private val testTeacherSchedule = TeacherSchedule(
     available = listOf(
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T04:30:00Z",
             endUtc = "2023-07-31T09:30:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T13:30:00Z",
             endUtc = "2023-07-31T18:30:00Z",
         ),
     ),
     booked = listOf(
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T09:30:00Z",
             endUtc = "2023-07-31T10:00:00Z",
         ),
-        NetworkTimeSlots(
+        TimeSlots(
             startUtc = "2023-07-31T11:30:00Z",
             endUtc = "2023-07-31T13:30:00Z",
         ),


### PR DESCRIPTION
Previously, the repository directly returned NetworkTeacherSchedule, a network response model.
To decouple the network layer from the app's core logic, the repository now returns TeacherSchedule, an internal model more suitable for app usage.